### PR TITLE
Add customer type

### DIFF
--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -75,6 +75,7 @@ require 'quickbooks/model/invoice_line_item'
 require 'quickbooks/model/invoice_group_line_detail'
 require 'quickbooks/model/company_info'
 require 'quickbooks/model/company_currency'
+require 'quickbooks/model/customer_type'
 require 'quickbooks/model/customer'
 require 'quickbooks/model/delivery_info'
 require 'quickbooks/model/sales_receipt'
@@ -137,6 +138,7 @@ require 'quickbooks/service/class'
 require 'quickbooks/service/attachable'
 require 'quickbooks/service/company_info'
 require 'quickbooks/service/company_currency'
+require 'quickbooks/service/customer_type'
 require 'quickbooks/service/customer'
 require 'quickbooks/service/department'
 require 'quickbooks/service/invoice'
@@ -246,6 +248,7 @@ module Quickbooks
   class TooManyRequests < Error; end
   class ServiceUnavailable < Error; end
   class MissingRealmError < Error; end
+  class UnsupportedOperation < Error; end
 
   class IntuitRequestException < Error
     attr_accessor :message, :code, :detail, :type, :intuit_tid, :request_xml, :request_json

--- a/lib/quickbooks/model/customer.rb
+++ b/lib/quickbooks/model/customer.rb
@@ -57,12 +57,14 @@ module Quickbooks
       xml_accessor :currency_ref, :from => 'CurrencyRef', :as => BaseReference
       xml_accessor :tax_exemption_reason_id, :from => 'TaxExemptionReasonId'
       xml_accessor :primary_tax_identifier, :from => 'PrimaryTaxIdentifier'
+      xml_accessor :customer_type_ref, :from => 'CustomerTypeRef', :as => BaseReference
 
       #== Validations
       validate :names_cannot_contain_invalid_characters
       validate :email_address_is_valid
 
-      reference_setters :parent_ref, :sales_term_ref, :payment_method_ref, :default_tax_code_ref, :currency_ref
+      reference_setters :parent_ref, :sales_term_ref, :payment_method_ref, :default_tax_code_ref, :currency_ref,
+                        :customer_type_ref
 
       def job?
         job.to_s == 'true'

--- a/lib/quickbooks/model/customer_type.rb
+++ b/lib/quickbooks/model/customer_type.rb
@@ -1,0 +1,15 @@
+module Quickbooks
+  module Model
+    class CustomerType < BaseModel
+      XML_COLLECTION_NODE = "CustomerType"
+      XML_NODE = "CustomerType"
+      REST_RESOURCE = 'customertype'
+
+      xml_accessor :id, :from => 'Id'
+      xml_accessor :sync_token, :from => 'SyncToken', :as => Integer
+      xml_accessor :meta_data, :from => 'MetaData', :as => MetaData
+      xml_accessor :name, :from => 'Name'
+      xml_accessor :active?, :from => 'Active'
+    end
+  end
+end

--- a/lib/quickbooks/service/customer_type.rb
+++ b/lib/quickbooks/service/customer_type.rb
@@ -1,0 +1,20 @@
+module Quickbooks
+  module Service
+    class CustomerType < BaseService
+
+      def delete(customer_type)
+        raise Quickbooks::UnsupportedOperation.new('Deleting CustomerType is not supported by Intuit')
+      end
+
+      def create(customer_type)
+        raise Quickbooks::UnsupportedOperation.new('Creating/updating CustomerType is not supported by Intuit')
+      end
+
+      private
+
+      def model
+        Quickbooks::Model::CustomerType
+      end
+    end
+  end
+end

--- a/spec/fixtures/customer.xml
+++ b/spec/fixtures/customer.xml
@@ -46,4 +46,5 @@
   <BalanceWithJobs>0</BalanceWithJobs>
   <PreferredDeliveryMethod>Email</PreferredDeliveryMethod>
   <CurrencyRef name="British Pound Sterling">GBP</CurrencyRef>
+  <CustomerTypeRef>5000000000000000185</CustomerTypeRef>
 </Customer>

--- a/spec/fixtures/customer_type.xml
+++ b/spec/fixtures/customer_type.xml
@@ -1,0 +1,10 @@
+<CustomerType domain="QBO" sparse="false">
+  <Id>1</Id>
+  <SyncToken>1</SyncToken>
+  <MetaData>
+    <CreateTime>2020-02-26T05:40:25-07:00</CreateTime>
+    <LastUpdatedTime>2020-02-26T05:40:25-07:00</LastUpdatedTime>
+  </MetaData>
+  <Name>Retail</Name>
+  <Active>true</Active>
+</CustomerType>

--- a/spec/fixtures/customer_types.xml
+++ b/spec/fixtures/customer_types.xml
@@ -1,0 +1,44 @@
+<IntuitResponse xmlns="http://schema.intuit.com/finance/v3" time="2020-02-27T12:04:53.709-07:00">
+  <QueryResponse startPosition="1" maxResults="4" totalCount="4">
+    <CustomerType domain="QBO" sparse="false">
+      <Id>1</Id>
+      <SyncToken>0</SyncToken>
+      <MetaData>
+        <CreateTime>2020-02-26T05:40:25-07:00</CreateTime>
+        <LastUpdatedTime>2020-02-26T05:40:25-07:00</LastUpdatedTime>
+      </MetaData>
+      <Name>Retail</Name>
+      <Active>true</Active>
+    </CustomerType>
+    <CustomerType domain="QBO" sparse="false">
+      <Id>2</Id>
+      <SyncToken>0</SyncToken>
+      <MetaData>
+        <CreateTime>2020-02-26T05:40:47-07:00</CreateTime>
+        <LastUpdatedTime>2020-02-26T05:40:47-07:00</LastUpdatedTime>
+      </MetaData>
+      <Name>Drop Ship</Name>
+      <Active>true</Active>
+    </CustomerType>
+    <CustomerType domain="QBO" sparse="false">
+      <Id>3</Id>
+      <SyncToken>0</SyncToken>
+      <MetaData>
+        <CreateTime>2020-02-26T05:40:34-07:00</CreateTime>
+        <LastUpdatedTime>2020-02-26T05:40:34-07:00</LastUpdatedTime>
+      </MetaData>
+      <Name>Distributor</Name>
+      <Active>true</Active>
+    </CustomerType>
+    <CustomerType domain="QBO" sparse="false">
+      <Id>4</Id>
+      <SyncToken>0</SyncToken>
+      <MetaData>
+        <CreateTime>2020-02-26T05:40:50-07:00</CreateTime>
+        <LastUpdatedTime>2020-02-26T05:40:50-07:00</LastUpdatedTime>
+      </MetaData>
+      <Name>Wholesale</Name>
+      <Active>true</Active>
+    </CustomerType>
+  </QueryResponse>
+</IntuitResponse>

--- a/spec/fixtures/fetch_customer_type_by_id.xml
+++ b/spec/fixtures/fetch_customer_type_by_id.xml
@@ -1,0 +1,12 @@
+<IntuitResponse xmlns="http://schema.intuit.com/finance/v3" time="2020-02-27T17:38:30.868-07:00">
+  <CustomerType domain="QBO" sparse="false">
+    <Id>2</Id>
+    <SyncToken>2</SyncToken>
+    <MetaData>
+      <CreateTime>2020-02-26T05:40:25-07:00</CreateTime>
+      <LastUpdatedTime>2020-02-26T05:40:25-07:00</LastUpdatedTime>
+    </MetaData>
+    <Name>Drop Ship</Name>
+    <Active>true</Active>
+  </CustomerType>
+</IntuitResponse>

--- a/spec/lib/quickbooks/model/customer_spec.rb
+++ b/spec/lib/quickbooks/model/customer_spec.rb
@@ -43,6 +43,7 @@ describe "Quickbooks::Model::Customer" do
 
     expect(customer.currency_ref.name).to eq("British Pound Sterling")
     expect(customer.currency_ref.value).to eq("GBP")
+    expect(customer.customer_type_ref.value).to eq("5000000000000000185")
   end
 
   it "can assign an email address" do

--- a/spec/lib/quickbooks/model/customer_type_spec.rb
+++ b/spec/lib/quickbooks/model/customer_type_spec.rb
@@ -1,0 +1,11 @@
+describe "Quickbooks::Model::CustomerType" do
+
+  it "parse from XML" do
+    xml = fixture("customer_type.xml")
+    customer_type = Quickbooks::Model::CustomerType.from_xml(xml)
+    expect(customer_type.sync_token).to eq 1
+    expect(customer_type.name).to eq 'Retail'
+    expect(customer_type.active?).to eq true
+  end
+
+end

--- a/spec/lib/quickbooks/service/customer_type_spec.rb
+++ b/spec/lib/quickbooks/service/customer_type_spec.rb
@@ -1,0 +1,52 @@
+describe "Quickbooks::Service::CustomerType" do
+  before(:all) do
+    construct_service :customer_type
+  end
+
+  it "can query for customer types" do
+    xml = fixture("customer_types.xml")
+    model = Quickbooks::Model::CustomerType
+    stub_http_request(:get, @service.url_for_query, ["200", "OK"], xml)
+    customer_types = @service.query
+    expect(customer_types.entries.count).to eq(4)
+    customer_type1 = customer_types.entries[0]
+    expect(customer_type1.name).to eq('Retail')
+    customer_type2 = customer_types.entries[1]
+    expect(customer_type2.name).to eq('Drop Ship')
+    customer_type3 = customer_types.entries[2]
+    expect(customer_type3.name).to eq('Distributor')
+    customer_type4 = customer_types.entries[3]
+    expect(customer_type4.name).to eq('Wholesale')
+  end
+
+  it "can fetch a customer type by ID" do
+    xml = fixture("fetch_customer_type_by_id.xml")
+    model = Quickbooks::Model::CustomerType
+    stub_http_request(:get, "#{@service.url_for_resource(model::REST_RESOURCE)}/2", ["200", "OK"], xml)
+    customer_type = @service.fetch_by_id(2)
+    expect(customer_type.name).to eq('Drop Ship')
+  end
+
+  it "cannot create a customer type" do
+    customer_type = Quickbooks::Model::CustomerType.new
+    customer_type.name = 'New Type'
+    expect{ @service.create(customer_type) }.to raise_error(Quickbooks::UnsupportedOperation, "Creating/updating CustomerType is not supported by Intuit")
+  end
+
+  it "cannot update a customer type" do
+    customer_type = Quickbooks::Model::CustomerType.new
+    customer_type.name = 'New Type'
+    customer_type.id = 1
+    customer_type.sync_token = 1
+    expect{ @service.create(customer_type) }.to raise_error(Quickbooks::UnsupportedOperation, "Creating/updating CustomerType is not supported by Intuit")
+  end
+
+  it "cannot delete a customer type" do
+    customer_type = Quickbooks::Model::CustomerType.new
+    customer_type.name = 'New Type'
+    customer_type.id = 1
+    customer_type.sync_token = 1
+    expect{ @service.delete(customer_type) }.to raise_error(Quickbooks::UnsupportedOperation, "Deleting CustomerType is not supported by Intuit")
+  end
+
+end


### PR DESCRIPTION
This adds a customer_type_ref to the customer object as well as querying capabilities. Creating/updating/deleting of customer types is not supported by QuickBooks.